### PR TITLE
Made rope.cs easier to read

### DIFF
--- a/Cut the Rope/Assets/Rope.cs
+++ b/Cut the Rope/Assets/Rope.cs
@@ -23,16 +23,10 @@ public class Rope : MonoBehaviour {
 			HingeJoint2D joint = link.GetComponent<HingeJoint2D>();
 			joint.connectedBody = previousRB;
 
-			if (i < links - 1)
-			{
-				previousRB = link.GetComponent<Rigidbody2D>();
-			} else
-			{
-				weigth.ConnectRopeEnd(link.GetComponent<Rigidbody2D>());
-			}
-
-			
+			previousRB = link.GetComponent<Rigidbody2D>();			
 		}
+		
+		weigth.ConnectRopeEnd(previousRB);
 	}
 
 }


### PR DESCRIPTION
By moving the ConnectEndRope statement, it's easier to follow the flow of the program. Also, the script is faster since it doesn't have an if to test